### PR TITLE
Check all intents when determining direct dependency details

### DIFF
--- a/lib/Deparser.js
+++ b/lib/Deparser.js
@@ -57,17 +57,20 @@ class Deparser {
         // Assign id (index) to each dependency to use id when creating edges
         Object.keys(this.lockFilePackages).map((pkg) => {
           const lockFileEntry = this.lockFilePackages[pkg];
+          const depName = pkg.substring(pkg.lastIndexOf('@'), 0);
+          const depType = this.getDependencyType(pkg);
+          const intent = pkg.substring(pkg.lastIndexOf('@') + 1);
+
           if (lockFileEntry.id === undefined) {
             lockFileEntry.id = entryId;
             this.normalizedLockFileEntries[pkg] = lockFileEntry;
-            const depType = this.getDependencyType(pkg);
-            if (depType) {
-              const depName = pkg.substring(pkg.lastIndexOf('@'), 0);
-              const intent = pkg.substring(pkg.lastIndexOf('@') + 1);
-              this.lockFilePackages[rootPackage].dependencies[depName] = intent;
-              this.directDependencyTypesMap[entryId] = depType;
-            }
             entryId = entryId + 1;
+          }
+
+          // We're handling a separate intent that's resolved to the same lockfile package a previous intent has resolved to.
+          if (depType && !this.lockFilePackages[rootPackage].dependencies[depName]) {
+            this.lockFilePackages[rootPackage].dependencies[depName] = intent;
+            this.directDependencyTypesMap[lockFileEntry.id] = depType;
           }
         });
       } else {
@@ -155,13 +158,12 @@ class Deparser {
   
     Object.keys(this.normalizedLockFileEntries).forEach(dep => {
       const dependency = this.normalizedLockFileEntries[dep];
-      const dependencyType = this.getDependencyType(dep);
       const result = {
         name: dep.substring(dep.lastIndexOf('@'), 0),
         version: dependency.version,
         id: dependency.id
       };
-      result.dependencyType = dependencyType || DEP_TYPES.DEP.output;
+      result.dependencyType = this.directDependencyTypesMap[dependency.id] || DEP_TYPES.DEP.output;
 
       Object.keys(DEP_TYPES).forEach(depType => {
         if (dependency[DEP_TYPES[depType].source]) {

--- a/lib/Deparser.js
+++ b/lib/Deparser.js
@@ -61,13 +61,14 @@ class Deparser {
           const depType = this.getDependencyType(pkg);
           const intent = pkg.substring(pkg.lastIndexOf('@') + 1);
 
+          // If it's the first time we're processing this lock file entry, generate a unique ID.
           if (lockFileEntry.id === undefined) {
             lockFileEntry.id = entryId;
             this.normalizedLockFileEntries[pkg] = lockFileEntry;
             entryId = entryId + 1;
           }
 
-          // We're handling a separate intent that's resolved to the same lockfile package a previous intent has resolved to.
+          // If we haven't established any direct dependency on this package yet, try to do so.
           if (depType && !this.lockFilePackages[rootPackage].dependencies[depName]) {
             this.lockFilePackages[rootPackage].dependencies[depName] = intent;
             this.directDependencyTypesMap[lockFileEntry.id] = depType;

--- a/test/fixture/package.json
+++ b/test/fixture/package.json
@@ -13,5 +13,8 @@
   },
   "optionalDependencies": {
     "fsevents": "^1.2.4"
+  },
+  "resolutions": {
+    "mocha": "^5.1.0"
   }
 }

--- a/test/fixture/yarn.lock
+++ b/test/fixture/yarn.lock
@@ -305,7 +305,7 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@^5.2.0:
+mocha@^5.1.0, mocha@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/mocha/-/mocha-5.2.0.tgz#6d8ae508f59167f940f2b5b3c4a612ae50c90ae6"
   dependencies:


### PR DESCRIPTION
For multiple intents resolving to the same lock file entry, don't rely only on the first one when getting direct dependency information.

This would result in bugs like:
- Edges missing when the first intent was from a resolution
- Edges missing when a transitive intent is resolved before a direct intent

Updated a test to check this case as well.